### PR TITLE
2.21 changes

### DIFF
--- a/RocketLeagueReplayParser/NetworkStream/ActorStateProperty.cs
+++ b/RocketLeagueReplayParser/NetworkStream/ActorStateProperty.cs
@@ -85,7 +85,9 @@ namespace RocketLeagueReplayParser.NetworkStream
                 case "Engine.PlayerReplicationInfo:RemoteUserData":
                 case "TAGame.GRI_TA:NewDedicatedServerIP":
                 case "ProjectX.GRI_X:MatchGUID":
+                case "ProjectX.GRI_X:MatchGuid": // Can remove as duplicate in case the comparison is ever made case insensitive
                 case "TAGame.PRI_TA:CurrentVoiceRoom":
+                case "ProjectX.GRI_X:ReplicatedServerRegion":
                     asp.Data = br.ReadString();
                     break;
                 case "TAGame.GameEvent_Soccar_TA:SecondsRemaining":
@@ -407,6 +409,8 @@ namespace RocketLeagueReplayParser.NetworkStream
                 case "Engine.PlayerReplicationInfo:RemoteUserData":
                 case "TAGame.GRI_TA:NewDedicatedServerIP":
                 case "ProjectX.GRI_X:MatchGUID":
+                case "ProjectX.GRI_X:MatchGuid":
+                case "ProjectX.GRI_X:ReplicatedServerRegion":
                     ((string)data).Serialize(bw);
                     break;
                 case "TAGame.GameEvent_Soccar_TA:SecondsRemaining":

--- a/RocketLeagueReplayParser/NetworkStream/ActorStateProperty.cs
+++ b/RocketLeagueReplayParser/NetworkStream/ActorStateProperty.cs
@@ -409,7 +409,7 @@ namespace RocketLeagueReplayParser.NetworkStream
                 case "Engine.PlayerReplicationInfo:RemoteUserData":
                 case "TAGame.GRI_TA:NewDedicatedServerIP":
                 case "ProjectX.GRI_X:MatchGUID":
-                case "ProjectX.GRI_X:MatchGuid":
+                case "ProjectX.GRI_X:MatchGuid": // Can remove as duplicate in case the comparison is ever made case insensitive
                 case "ProjectX.GRI_X:ReplicatedServerRegion":
                     ((string)data).Serialize(bw);
                     break;


### PR DESCRIPTION
New property ProjectX.GRI_X:ReplicatedServerRegion.

The casing for property ProjectX.GRI_X:MatchGUID was changed, so now you need to have them both in order to keep both new and old replays working.

Could also be mitigated by changing the comparison to be case insensitive. But I don't think I want to open that can of worms and see what pops out.